### PR TITLE
feat: Add bug report template for GitHub issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,53 @@
+---
+name: 🐛 Bug Report
+about: Create a report to help us improve GitHub Project Fetch
+title: '[BUG] '
+labels: ['bug', 'needs-triage']
+assignees: ['joe-sharp']
+---
+
+## 🎯 What's the problem?
+
+**Brief description of the bug:**
+
+## 🔍 How to reproduce
+
+**Steps to reproduce the behavior:**
+1. Call API endpoint: `...`
+2. With parameters: `...`
+3. See error: `...`
+
+## 🎴 What should happen?
+
+**Expected behavior:**
+
+## ❌ What actually happens?
+
+**Actual behavior:**
+
+## 📋 Environment
+
+- **OS:** [e.g. macOS, Ubuntu, Windows]
+- **Ruby:** [e.g. 3.3.8]
+- **GitHub Project Fetch:** [e.g. 1.0.0]
+- **Browser or Client:** [e.g. Chrome, Postman]
+
+## 🔧 API Details (if applicable)
+
+**Endpoint:** [e.g. `/api/projects?username`]
+**Response/Error:**
+```json
+{
+  "error": "Your error response here"
+}
+```
+
+## 📝 Checklist
+
+- [ ] I have searched existing issues to avoid duplicates
+- [ ] I have provided all required environment information
+- [ ] I have included a minimal reproduction case
+
+---
+
+**Note:** This tool fetches public repository data from GitHub. Please ensure you're not sharing sensitive information in your bug report.


### PR DESCRIPTION
- Introduced a new bug report template to streamline issue reporting.
- The template includes sections for problem description, reproduction steps, expected vs actual behavior, environment details, and a checklist to ensure completeness.
- Fixes #4