### PR TITLE
feat: Implement caching for API responses to improve performance

### DIFF
--- a/api/health.rb
+++ b/api/health.rb
@@ -16,7 +16,16 @@ Handler = proc do |request, response|
     result = health_service.check_health
 
     status = result[:status] == 'healthy' ? 200 : 503
-    GithubRepoFetcher::ApiResponseService.success_response(response, result, status)
+
+    # Cache health status for 10 seconds with 1 minutes stale-while-revalidate
+    # Health checks should be fresh but can tolerate some staleness
+    GithubRepoFetcher::ApiResponseService.cached_success_response(
+      response,
+      result,
+      10, # 10 seconds cache
+      60, # 1 minute stale-while-revalidate
+      status
+    )
   rescue StandardError => e
     GithubRepoFetcher::ApiResponseService.error_response(response, e.message, 503)
   end

--- a/api/health.rb
+++ b/api/health.rb
@@ -17,7 +17,7 @@ Handler = proc do |request, response|
 
     status = result[:status] == 'healthy' ? 200 : 503
 
-    # Cache health status for 10 seconds with 1 minutes stale-while-revalidate
+    # Cache health status for 10 seconds with 1 minute stale-while-revalidate
     # Health checks should be fresh but can tolerate some staleness
     GithubRepoFetcher::ApiResponseService.cached_success_response(
       response,

--- a/api/index.rb
+++ b/api/index.rb
@@ -29,7 +29,15 @@ Handler = proc do |request, response|
           projects: '/api/projects?octocat'
         }
       }
-      GithubRepoFetcher::ApiResponseService.success_response(response, data)
+
+      # Cache API documentation for 1 hour with 2 hours stale-while-revalidate
+      # Documentation rarely changes and can be cached longer
+      GithubRepoFetcher::ApiResponseService.cached_success_response(
+        response,
+        data,
+        3600,  # 1 hour cache
+        7200   # 2 hours stale-while-revalidate
+      )
     else
       GithubRepoFetcher::ApiResponseService.not_found_response(response)
     end

--- a/api/projects.rb
+++ b/api/projects.rb
@@ -19,7 +19,14 @@ Handler = proc do |request, response|
     project_service = GithubRepoFetcher::ProjectService.new
     result = project_service.fetch_user_projects(username)
 
-    GithubRepoFetcher::ApiResponseService.success_response(response, result)
+    # Cache GitHub data for 10 minutes with 20 minutes stale-while-revalidate
+    # This balances freshness with performance for public repository data
+    GithubRepoFetcher::ApiResponseService.cached_success_response(
+      response,
+      result,
+      600, # 10 minutes cache
+      1200 # 20 minutes stale-while-revalidate
+    )
   rescue ArgumentError => e
     GithubRepoFetcher::ApiResponseService.bad_request_response(response, e.message)
   rescue StandardError => e

--- a/lib/github_repo_fetcher/api_response_service.rb
+++ b/lib/github_repo_fetcher/api_response_service.rb
@@ -22,9 +22,19 @@ module GithubRepoFetcher
       end
     end
 
+    # Add cache control headers for Vercel Edge Caching
+    def self.add_cache_headers(response, max_age, stale_while_revalidate)
+      response['Cache-Control'] = "s-maxage=#{max_age}, stale-while-revalidate=#{stale_while_revalidate}"
+    end
+
     def self.success_response(response, data, status = 200)
       response.status = status
       response.body = data.to_json
+    end
+
+    def self.cached_success_response(response, data, max_age = 600, stale_while_revalidate = 1200, status = 200)
+      add_cache_headers(response, max_age, stale_while_revalidate)
+      success_response(response, data, status)
     end
 
     def self.error_response(response, error_message, status = 500)


### PR DESCRIPTION
- Enhanced ApiResponseService to support cached responses and added cache control headers for Vercel Edge Caching.
- Configured the endpoints with the following cache values:
  - api: 1 hour cache and 2 hours stale-while-revalidate.
  - api/health: 10 seconds cache and 1 minute stale-while-revalidate.
  - api/projects: 10 minutes cache and 20 minutes stale-while-revalidate.

Fixes #6